### PR TITLE
feat: added ignore-detached-head command line flag

### DIFF
--- a/cli/common_opts/opts.go
+++ b/cli/common_opts/opts.go
@@ -1,3 +1,4 @@
 package common_opts
 
 var Workdir = ""
+var IgnoreDetachedHead = false

--- a/cli/main.go
+++ b/cli/main.go
@@ -42,6 +42,7 @@ func main() {
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&common_opts.Workdir, "workdir", "w", ".", "Working directory to use")
 	rootCmd.PersistentFlags().String("log-level", logger.DEFAULT_LOG_LEVEL.String(), "panic | fatal | error | warn | info | debug | trace")
+	rootCmd.PersistentFlags().BoolVar(&common_opts.IgnoreDetachedHead, "ignore-detached-head", false, "Specifies to ignore detached head errors")
 }
 
 func processLogLevelFlag(cmd *cobra.Command) {

--- a/cli/next/command.go
+++ b/cli/next/command.go
@@ -21,8 +21,9 @@ var Command = cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		nextVersion, err := next.Next(next.NextOptions{
-			Workdir: common_opts.Workdir,
-			Stable:  stable,
+			Workdir:            common_opts.Workdir,
+			IgnoreDetachedHead: common_opts.IgnoreDetachedHead,
+			Stable:             stable,
 			MajorVersionFilter: majorVersionFilter,
 			PreReleaseOptions: semver.PreReleaseOptions{
 				Label:         preReleaseTag,
@@ -44,4 +45,5 @@ func init() {
 	Command.Flags().IntVar(&majorVersionFilter, "major-version", -1, "Only consider tags with this specific major version.")
 	Command.Flags().StringVar(&preReleaseTag, "pre-release-tag", "", "Specifies a pre-release tag which should be appended to the next version.")
 	Command.Flags().BoolVar(&appendPreReleaseCounter, "pre-release-counter", false, "Specifies if there should be a counter appended to the pre-release tag. It will increase automatically depending on previous pre-releases for the same version.")
+
 }

--- a/next/next.go
+++ b/next/next.go
@@ -17,6 +17,7 @@ type NextOptions struct {
 	Stable             bool
 	MajorVersionFilter int
 	PreReleaseOptions  semver.PreReleaseOptions
+	IgnoreDetachedHead bool
 }
 
 func Next(options NextOptions) (*semver.Version, error) {
@@ -41,7 +42,7 @@ func Next(options NextOptions) (*semver.Version, error) {
 		return nil, errors.WithMessage(err, "Error while trying to find latest release version tag")
 	}
 
-	if latestReleaseVersionTag != nil {
+	if latestReleaseVersionTag != nil && !options.IgnoreDetachedHead {
 		if err = git_utils.AssertRefIsReachable(repo, latestReleaseVersionTag, headRef, "Latest tag is not on HEAD. This is necessary as the next version is calculated based on the commits since the latest version tag."); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
We have experienced, when someone is committing changes while our build process is running with and including commits, for example when updating pom file version, it breaks the build process, simply ignoring the detached head fixes it for us.