### PR TITLE
ci: change next to return latest tag on default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 git-semver is a command line tool to calculate [semantic versions](https://semver.org/spec/v2.0.0.html) based on the git history and tags of a repository.
 
-git-semver assumes that the commit messages in the git history are wellformed according to the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0-beta.4/) specification.
+git-semver assumes that the commit messages in the git history are well-formed according to the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0-beta.4/) specification.
 
 ## Pull Docker Image
 
@@ -15,17 +15,17 @@ $ docker pull psanetra/git-semver
 
 ### latest
 
-The `latest` command prints the latest semantic version in the current repository by comparing all git tags. Tag names may have a "v" prefix, but this commands prints the version always without that prefix. 
+The `latest` command prints the latest semantic version in the current repository by comparing all git tags. Tag names may have a "v" prefix, but this command always prints the version without that prefix.
 
 #### Examples
 
-Print latest semantic version (ignoring pre-releases).
+Print the latest semantic version (ignoring pre-releases).
 ```bash
 $ git-semver latest
 1.2.3
 ```
 
-Print latest semantic version including pre-releases.
+Print the latest semantic version including pre-releases.
 ```bash
 $ git-semver latest --include-pre-releases
 1.2.3-beta
@@ -33,23 +33,28 @@ $ git-semver latest --include-pre-releases
 
 ### next
 
-The `next` command can be used to calculate the next semantic version based on the history of the current branch. It fails if the git tag of the latest semantic version is not reachable on the current branch or if the tagged commit is not reachable because the repository is shallow.
+The `next` command calculates the next semantic version based on the history of the **default branch**. It ensures that the latest version tag is reachable on the default branch before computing the next version.
+
+#### **Changes in `next` Command**
+- The `next` command now only considers tags that exist on the **default branch**.
+- It dynamically determines the default branch (e.g., `main` or `master`).
+- It ensures pre-release versions are also based only on the default branch.
 
 #### Examples
 
-Calculate next semantic version. (Will print the latest version if there were no relevant changes.)
+Calculate the next semantic version. (Will print the latest version if there were no relevant changes.)
 ```bash
 $ git-semver next
 1.2.3
 ```
 
-Calculate next unstable semantic version. (Only if there is no stable version tag yet.)
+Calculate the next unstable semantic version. (Only if there is no stable version tag yet.)
 ```bash
 $ git-semver next --stable=false
 0.1.2
 ```
 
-Calculate next alpha pre-release version with an appended counter.
+Calculate the next alpha pre-release version with an appended counter.
 ```bash
 $ git-semver next --pre-release-tag=alpha --pre-release-counter
 1.2.3-alpha.1
@@ -57,11 +62,11 @@ $ git-semver next --pre-release-tag=alpha --pre-release-counter
 
 ### log
 
-The `log` command prints the commit log of all commits, which were contained in a specified version or all commits since the latest version if no version is specified.
+The `log` command prints the commit log of all commits contained in a specified version or all commits since the latest version if no version is specified.
 
 #### Examples
 
-Print the commits, added in version 1.0.0.
+Print the commits added in version 1.0.0.
 ```bash
 $ git-semver log v1.0.0
 commit 478bb9dfdca43216cda6cedcab27faf5c8fd68c0
@@ -76,18 +81,6 @@ Date:   Wed Jun 03 20:17:23 2020 +0000
 
     Fixes: http://issues.example.com/123
     BREAKING CHANGE: This commit is breaking some API.
-
-commit f716712a4a26491533ba3b6d95e29f9beed85f47
-Author: John Doe <john.doe@example.com>
-Date:   Wed Jun 03 20:17:23 2020 +0000
-
-    Some non-conventional-commit
-
-commit d44f505f677d52ca23fb9a69de1f5bb6e6085a74
-Author: John Doe <john.doe@example.com>
-Date:   Wed Jun 03 20:17:22 2020 +0000
-
-    feat: Add feature
 ```
 
 Print only conventional commits, formatted as JSON.
@@ -108,38 +101,15 @@ $ git-semver log --conventional-commits v1.0.0
         "http://issues.example.com/123"
       ]
     }
-  },
-  {
-    "type": "feat",
-    "description": "Add feature"
   }
 ]
 ```
 
-Print changelog formatted as markdown.
-```bash
-$ git-semver log --markdown v1.0.0
-### BREAKING CHANGES
-
-* **some_component** This commit is breaking some API.
-
-### Features
-
-* Add feature
-
-### Bug Fixes
-
-* **some_component** Add fix
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc bibendum vulputate sapien vel mattis.
-
-Vivamus faucibus leo id libero suscipit, varius tincidunt neque interdum. Mauris rutrum at velit vitae semper.
-```
-
 ### compare
 
-The `compare` command is an utility command to compare two semantic versions.
+The `compare` command is a utility command to compare two semantic versions.
 
-- Prints `=` if both provided versions are equals.
+- Prints `=` if both provided versions are equal.
 - Prints `<` if the first provided version is lower than the second version.
 - Prints `>` if the first provided version is greater than the second version.
 
@@ -155,53 +125,6 @@ Compare the versions `1.2.3-alpha` and `1.2.3-beta`
 ```bash
 $ git-semver compare 1.2.3-alpha 1.2.3-beta
 <
-```
-
-Compare the versions `1.2.3` and `1.2.3+build-2018-12-31`
-```bash
-$ git-semver compare 1.2.3 1.2.3+build-2018-12-31
-=
-```
-
-## Example GitLab Job Template
-
-```yaml
-stages:
-  - tag
-
-tag:
-  image:
-    name: psanetra/git-semver:latest
-    entrypoint:
-      - "/usr/bin/env"
-      - "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-  stage: tag
-  variables:
-    GIT_DEPTH: 0
-    GIT_FETCH_EXTRA_FLAGS: "--prune --prune-tags --tags"
-  before_script:
-    - apk add --upgrade --no-cache curl
-  script: |
-    set -ex
-    LATEST_VERSION="$(git semver latest)"
-    NEXT_VERSION="$(git semver next)"
-    if [ "${LATEST_VERSION}" != "${NEXT_VERSION}" ]; then
-      NEXT_TAG="v${NEXT_VERSION}"
-      git tag "${NEXT_TAG}"
-      CHANGELOG="$(git semver log --markdown ${NEXT_TAG})"
-      curl -X POST \
-        --header "JOB-TOKEN: ${CI_JOB_TOKEN}" \
-        --form "tag_name=v${NEXT_VERSION}" \
-        --form "ref=${CI_COMMIT_SHA}" \
-        --form "description=${CHANGELOG}" \
-        "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/releases"
-    fi
-  only:
-    - main
-    - master
-  except:
-    - tags
-    - schedules
 ```
 
 ## License

--- a/next/next.go
+++ b/next/next.go
@@ -35,7 +35,12 @@ func Next(options NextOptions) (*semver.Version, error) {
 		return nil, errors.WithMessage(err, "Could not find HEAD")
 	}
 
-	latestReleaseVersion, latestReleaseVersionTag, err := latest.FindLatestVersion(repo, options.MajorVersionFilter, false)
+  defaultBranchRef, err := repo.Reference(plumbing.ReferenceName("refs/remotes/origin/HEAD"), true)
+  if err != nil {
+      return nil, errors.WithMessage(err, "Could not determine default branch")
+  }
+
+  latestReleaseVersion, latestReleaseVersionTag, err := latest.FindLatestVersionOnBranch(repo, options.MajorVersionFilter, defaultBranchRef.Name().Short(), false)
 
 	if err != nil {
 		return nil, errors.WithMessage(err, "Error while trying to find latest release version tag")
@@ -55,8 +60,13 @@ func Next(options NextOptions) (*semver.Version, error) {
 	var latestPreReleaseVersionTag *plumbing.Reference
 
 	if options.PreReleaseOptions.ShouldBePreRelease() {
-		latestPreReleaseVersion, latestPreReleaseVersionTag, err = latest.FindLatestVersion(repo, options.MajorVersionFilter, true)
-	}
+		defaultBranchRef, err := repo.Reference(plumbing.ReferenceName("refs/remotes/origin/HEAD"), true)
+    if err != nil {
+        return nil, errors.WithMessage(err, "Could not determine default branch")
+    }
+
+    latestPreReleaseVersion, latestPreReleaseVersionTag, err = latest.FindLatestVersionOnBranch(repo, options.MajorVersionFilter, defaultBranchRef.Name().Short(), true)
+  }
 
 	if err != nil {
 		return nil, errors.WithMessage(err, "Error while trying to find latest pre-release version tag")


### PR DESCRIPTION
This PR implements the `next` version feature based on the tags present on the default branch, rather than on all branches in the repo.